### PR TITLE
Fix command typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ composer run preview
 To reinstall
 
 ```
-composer run cleanup
+composer run clean
 composer run preview
 ```
 


### PR DESCRIPTION
should be `composer run clean` instead of `composer run cleanup`