### PR TITLE
Revert "#3251940 Fix Config Sync Directory in composer script"

### DIFF
--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -40,7 +40,12 @@ class ScriptHandler {
       $fs->copy($drupalRoot . '/sites/default/default.settings.php', $drupalRoot . '/sites/default/settings.php');
       require_once $drupalRoot . '/core/includes/bootstrap.inc';
       require_once $drupalRoot . '/core/includes/install.inc';
-      $settings['config_sync_directory'] = Path::makeRelative($drupalFinder->getComposerRoot() . '/config/sync', $drupalRoot);
+      $settings['config_directories'] = [
+        CONFIG_SYNC_DIRECTORY => (object) [
+          'value' => Path::makeRelative($drupalFinder->getComposerRoot() . '/config/sync', $drupalRoot),
+          'required' => TRUE,
+        ],
+      ];
 
       // Workaround for Bootstrap https://www.drupal.org/project/bootstrap/issues/2667062
       $settings['settings']['maintenance_theme'] = (object) [


### PR DESCRIPTION
Reverts drupalcommerce/demo-project#62 - we treated the $settings array as the actual global settings array, not realizing it still required an object that would be converted to config. 🤦🏻‍♂️