### PR TITLE
WIP:Allowing some plugins in composer.json file for the Simplytest.me 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,16 @@
         "sort-packages": true,
         "platform": {
             "php": "7.3"
+        },
+        "allow-plugins": {
+            "cweagans/composer-patches": true,
+            "drupal/core-composer-scaffold": true,
+            "composer/installers": true,
+            "oomphinc/composer-installers-extender": true,
+            "webflo/drupal-finder": true,
+            "webmozart/path-util": true,
+            "zaporylie/composer-drupal-optimizations": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
     "require": {


### PR DESCRIPTION
This MR/PR is creating for the allowing some important plugins in composer file for [simplytest.me](https://simplytest.me/) project.  
While [simpytest.me](https://simplytest.me/) trying to show Drupal Commerce Demo then we found `cweagans/composer-patches contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe` this error. To resolve this I created this MR/PR. 